### PR TITLE
Conform to `0.3.0` of `typeid` spec

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,6 @@
+_help:
+  @just -l
+
 get:
   @dart pub get
 

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,12 @@ analyze:
   @dart analyze
 
 test:
-  @git submodule init
-  @git submodule update
-  @dart test
+  #!/bin/bash
+  set -euo pipefail
+
+  if git submodule status | grep -q '^-'; then
+      git submodule init
+      git submodule update
+  fi
+  
+  dart test

--- a/lib/src/typeid.dart
+++ b/lib/src/typeid.dart
@@ -26,7 +26,7 @@ class TypeId {
   /// Decodes a TypeID into a [DecodedTypeId]. Throws [FormatException] if
   /// the provided TypeID is invalid
   static DecodedTypeId decode(String typeid) {
-    final parts = typeid.split(separator);
+    final parts = _splitLast(typeid, separator);
 
     if (parts.length == 1) {
       parts.insert(0, '');
@@ -59,10 +59,27 @@ class TypeId {
       throw FormatException('Prefix too long');
     }
 
-    // ensure all characters fall within [a-z]
-    final isValid = prefix.runes.every((code) => code > 96 && code < 123);
+    if (prefix.startsWith(separator) || prefix.endsWith(separator)) {
+      throw FormatException('Prefix cannot start or end with $separator');
+    }
+
+    // ensure all characters fall within [a-z_]
+    final isValid =
+        prefix.runes.every((code) => (code > 96 && code < 123) || code == 95);
+
     if (!isValid) {
       throw FormatException('prefix must only contain lowercase letters [a-z]');
     }
+  }
+
+  static List<String> _splitLast(String input, String delimiter) {
+    int lastIndex = input.lastIndexOf(delimiter);
+    if (lastIndex == -1) {
+      // Delimiter not found, return the input as a single element list
+      return [input];
+    }
+    String beforeLast = input.substring(0, lastIndex);
+    String afterLast = input.substring(lastIndex + delimiter.length);
+    return [beforeLast, afterLast];
   }
 }

--- a/lib/typeid.dart
+++ b/lib/typeid.dart
@@ -1,6 +1,3 @@
-/// Support for doing something awesome.
-///
-/// More dartdocs go here.
 library;
 
 export 'package:uuid/uuid.dart' show UuidValue;
@@ -8,5 +5,3 @@ export 'package:uuid/uuid.dart' show UuidValue;
 export 'src/base32.dart';
 export 'src/typeid.dart';
 export 'src/decoded_typeid.dart';
-
-// TODO: Export any libraries intended for clients of this package.


### PR DESCRIPTION
Specifically, allows for `_` in typeid prefix. Related: https://github.com/jetify-com/typeid/issues/7